### PR TITLE
fix: correct grammar errors in content/02_getting_started.md

### DIFF
--- a/content/02_getting_started.md
+++ b/content/02_getting_started.md
@@ -408,7 +408,7 @@ In some rare cases, for example when you checkout a specific commit or tag or re
 
 ## Why staging is useful
 
-The index or staging are is a place to hold the current changes that will be committed when `git commit` is executed. It allows you to only commit parts of the working area into the respository. 
+The index or staging is a place to hold the current changes that will be committed when `git commit` is executed. It allows you to only commit parts of the working area into the repository. 
 
 For example, when you are working on a big feature with a few different subtasks, you can modify the files as you plan, then group the changes and add them separately to the staging area, and finally commit them with appropriate messages focused on the respective change. It also makes reviewing changes more straight-forward.
 


### PR DESCRIPTION
## Summary
Correct two grammar errors in content/02_getting_started.md:
- Line 411: 'staging are is' → 'staging is'
- Line 412: 'respository' → 'repository'

## Fixes
Fixes #7

## Testing
No code change - documentation only.